### PR TITLE
open uget-integrator link in a new tab

### DIFF
--- a/extension/popup.html
+++ b/extension/popup.html
@@ -103,7 +103,7 @@
             </div>
         </div>
         <row>
-            <label id="footer">For more details, visit <a href="https://github.com/ugetdm/uget-integrator/wiki/Installation">uget-integrator</a></label>
+            <label id="footer">For more details, visit <a href="https://github.com/ugetdm/uget-integrator/wiki/Installation" target="_blank">uget-integrator</a></label>
         </row>
 </body>
 


### PR DESCRIPTION
"uget-integrator" link in the extension popup is not opening in Google Chrome 67.
Adding the "target" attribute achieves the intended behavior.