### PR TITLE
Fix popup in private Firefox windows by replacing getBackgroundPage

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -103,6 +103,8 @@ function initialize() {
             setInterruptDownload(!interruptDownloads, true);
         }
     });
+    // Set internal popup.js message listener
+    current_browser.runtime.onMessage.addListener(handleInternalMessage);
     chromeVersion = parseInt(chromeVersion);
     sendMessageToHost(message);
     createContextMenus();
@@ -638,7 +640,7 @@ function parseCookies(cookies_arr) {
 
 /**
  * Update the exclude keywords.
- * Is called from the popup.js.
+ * Is triggered by the popup.js message handler.
  */
 function updateExcludeKeywords(exclude) {
     if (exclude === "") {
@@ -651,7 +653,7 @@ function updateExcludeKeywords(exclude) {
 
 /**
  * Update the include keywords.
- * Is called from the popup.js.
+ * Is triggered by the popup.js message handler.
  */
 function updateIncludeKeywords(include) {
     if (include === "") {
@@ -664,7 +666,7 @@ function updateIncludeKeywords(include) {
 
 /**
  * Update the exclude MIMEs.
- * Is called from the popup.js.
+ * Is triggered by the popup.js message handler.
  */
 function updateExcludeMIMEs(exclude) {
     if (exclude === "") {
@@ -677,7 +679,7 @@ function updateExcludeMIMEs(exclude) {
 
 /**
  * Update the include MIMEs.
- * Is called from the popup.js.
+ * Is triggered by the popup.js message handler.
  */
 function updateIncludeMIMEs(include) {
     if (include === "") {
@@ -690,11 +692,46 @@ function updateIncludeMIMEs(include) {
 
 /**
  * Update the minimum file size to interrupt.
- * Is called from the popup.js.
+ * Is triggered by the popup.js message handler.
  */
 function updateMinFileSize(size) {
     minFileSizeToInterrupt = size;
     current_browser.storage.sync.set({ "uget-min-file-size": size });
+}
+
+/**
+ * Handle messages within the extension.
+ * Is triggered by a popup.js message.
+ */
+function handleInternalMessage(message, sender, sendResponse) {
+    if (message.hasOwnProperty("get")) {
+        switch (message.get) {
+            case "state":
+                sendResponse({data: getState()});
+                break;
+        }
+    } else if (message.hasOwnProperty("update")) {
+        switch (message.update) {
+            case "interruptDownload":
+                setInterruptDownload(message.data, true);
+                break;
+            case "minFileSize":
+                updateMinFileSize(message.data);
+                break;
+            case "excludeKeywords":
+                updateExcludeKeywords(message.data);
+                break;
+            case "includeKeywords":
+                updateIncludeKeywords(message.data);
+                break;
+            case "excludeMIMEs":
+                updateExcludeMIMEs(message.data);
+                break;
+            case "includeMIMEs":
+                updateIncludeMIMEs(message.data);
+                break;
+        }
+    }
 }
 
 /**

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -20,6 +20,10 @@
 
 var current_browser;
 
+function sendMessageCallbabackToPromise(message, responseCallback) {
+    browser.runtime.sendMessage(message).then(responseCallback);
+}
+
 try {
     current_browser = browser;
     current_browser.runtime.getBrowserInfo().then(
@@ -29,14 +33,16 @@ try {
             }
         }
     );
+    compatSendMessage = sendMessageCallbabackToPromise;
 } catch (ex) {
     // Not Firefox
     current_browser = chrome;
+    compatSendMessage = current_browser.runtime.sendMessage
 }
 
 $(document).ready(function() {
     // Show the system status
-    current_browser.runtime.sendMessage({get: "state"}).then(function(response) {
+    compatSendMessage({get: "state"}, function(response) {
         var state = response.data;
         if (state == 0) {
             $('#info').css('display', 'block');
@@ -65,7 +71,7 @@ $(document).ready(function() {
     // Set event listeners
     $('#chk_enable').change(function() {
         var enabled = this.checked;
-        current_browser.runtime.sendMessage(
+        compatSendMessage(
             {update: "interruptDownload", data: enabled}
         );
     });
@@ -77,31 +83,31 @@ $(document).ready(function() {
             minFileSize = -1;
         }
         $('#fileSize').val(minFileSize);
-        current_browser.runtime.sendMessage(
+        compatSendMessage(
             {update: "minFileSize", data: minFileSize * 1024}
         );
     });
     $("#urlsToExclude").on("change paste", function() {
         var keywords = $(this).val().trim();
-        current_browser.runtime.sendMessage(
+        compatSendMessage(
             {update: "excludeKeywords", data: keywords}
         );
     });
     $("#urlsToInclude").on("change paste", function() {
         var keywords = $(this).val().trim();
-        current_browser.runtime.sendMessage(
+        compatSendMessage(
             {update: "includeKeywords", data: keywords}
         );
     });
     $("#mimeToExclude").on("change paste", function() {
         var keywords = $(this).val().trim();
-        current_browser.runtime.sendMessage(
+        compatSendMessage(
             {update: "excludeMIMEs", data: keywords}
         );
     });
     $("#mimeToInclude").on("change paste", function() {
         var keywords = $(this).val().trim();
-        current_browser.runtime.sendMessage(
+        compatSendMessage(
             {update: "includeMIMEs", data: keywords}
         );
     });

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -36,8 +36,8 @@ try {
 
 $(document).ready(function() {
     // Show the system status
-    current_browser.runtime.getBackgroundPage(function(backgroundPage) {
-        var state = backgroundPage.getState();
+    current_browser.runtime.sendMessage({get: "state"}).then(function(response) {
+        var state = response.data;
         if (state == 0) {
             $('#info').css('display', 'block');
             $('#warn').css('display', 'none');
@@ -65,9 +65,9 @@ $(document).ready(function() {
     // Set event listeners
     $('#chk_enable').change(function() {
         var enabled = this.checked;
-        current_browser.runtime.getBackgroundPage(function(backgroundPage) {
-            backgroundPage.setInterruptDownload(enabled, true);
-        });
+        current_browser.runtime.sendMessage(
+            {update: "interruptDownload", data: enabled}
+        );
     });
     $("#fileSize").on("change paste", function() {
         var minFileSize = parseInt($(this).val());
@@ -77,32 +77,32 @@ $(document).ready(function() {
             minFileSize = -1;
         }
         $('#fileSize').val(minFileSize);
-        current_browser.runtime.getBackgroundPage(function(backgroundPage) {
-            backgroundPage.updateMinFileSize(minFileSize * 1024);
-        });
+        current_browser.runtime.sendMessage(
+            {update: "minFileSize", data: minFileSize * 1024}
+        );
     });
     $("#urlsToExclude").on("change paste", function() {
         var keywords = $(this).val().trim();
-        current_browser.runtime.getBackgroundPage(function(backgroundPage) {
-            backgroundPage.updateExcludeKeywords(keywords);
-        });
+        current_browser.runtime.sendMessage(
+            {update: "excludeKeywords", data: keywords}
+        );
     });
     $("#urlsToInclude").on("change paste", function() {
         var keywords = $(this).val().trim();
-        current_browser.runtime.getBackgroundPage(function(backgroundPage) {
-            backgroundPage.updateIncludeKeywords(keywords);
-        });
+        current_browser.runtime.sendMessage(
+            {update: "includeKeywords", data: keywords}
+        );
     });
     $("#mimeToExclude").on("change paste", function() {
         var keywords = $(this).val().trim();
-        current_browser.runtime.getBackgroundPage(function(backgroundPage) {
-            backgroundPage.updateExcludeMIMEs(keywords);
-        });
+        current_browser.runtime.sendMessage(
+            {update: "excludeMIMEs", data: keywords}
+        );
     });
     $("#mimeToInclude").on("change paste", function() {
         var keywords = $(this).val().trim();
-        current_browser.runtime.getBackgroundPage(function(backgroundPage) {
-            backgroundPage.updateIncludeMIMEs(keywords);
-        });
+        current_browser.runtime.sendMessage(
+            {update: "includeMIMEs", data: keywords}
+        );
     });
 });


### PR DESCRIPTION
The extension popup fails in a private Firefox window because of [`getBackgroundPage`](https://bugzilla.mozilla.org/show_bug.cgi?id=1329304).

I replaced `getBackgroundPage` with `sendMessage` to communicate with the background script.

`sendMessage` has a [different API](https://bugs.chromium.org/p/chromium/issues/detail?id=328932) in Firefox and Chrome. So I had to add a workaround to work in both. It supports the simple case of sending an internal message and getting a response.

It does not support the `extensionId` and `options` arguments.

It does not support error handling. Firefox uses promises so it'll need a `.catch`. Chrome expects you to check `runtime.lastError` in the response callback. There is currently no error handling when using `sendMessage` in popup.js or `onMessage` in background.js.

I tested this in normal and private browsing in Firefox 76.0 and Chrome 80.0.3987.163. I changed the settings in the popup and verified that they persist when I open the popup again.

This fixes https://github.com/ugetdm/uget-integrator/issues/52.